### PR TITLE
Fix ctrl+enter not submitting toot when text cursor is composing image description

### DIFF
--- a/app/javascript/mastodon/features/compose/components/upload.js
+++ b/app/javascript/mastodon/features/compose/components/upload.js
@@ -20,6 +20,7 @@ export default class Upload extends ImmutablePureComponent {
     onUndo: PropTypes.func.isRequired,
     onDescriptionChange: PropTypes.func.isRequired,
     onOpenFocalPoint: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
   };
 
   state = {
@@ -27,6 +28,17 @@ export default class Upload extends ImmutablePureComponent {
     focused: false,
     dirtyDescription: null,
   };
+
+  handleKeyDown = (e) => {
+    if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
+      this.handleSubmit();
+    }
+  }
+
+  handleSubmit = () => {
+    this.handleInputBlur();
+    this.props.onSubmit();
+  }
 
   handleUndoClick = () => {
     this.props.onUndo(this.props.media.get('id'));
@@ -93,6 +105,7 @@ export default class Upload extends ImmutablePureComponent {
                     onFocus={this.handleInputFocus}
                     onChange={this.handleInputChange}
                     onBlur={this.handleInputBlur}
+                    onKeyDown={this.handleKeyDown}
                   />
                 </label>
               </div>

--- a/app/javascript/mastodon/features/compose/containers/upload_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_container.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import Upload from '../components/upload';
 import { undoUploadCompose, changeUploadCompose } from '../../../actions/compose';
 import { openModal } from '../../../actions/modal';
+import { submitCompose } from '../../../actions/compose';
 
 const mapStateToProps = (state, { id }) => ({
   media: state.getIn(['compose', 'media_attachments']).find(item => item.get('id') === id),
@@ -19,6 +20,10 @@ const mapDispatchToProps = dispatch => ({
 
   onOpenFocalPoint: id => {
     dispatch(openModal('FOCAL_POINT', { id }));
+  },
+
+  onSubmit () {
+    dispatch(submitCompose());
   },
 
 });


### PR DESCRIPTION
Created PR for tootsuite already (https://github.com/tootsuite/mastodon/pull/8273), but since I'm a cybre.space user I figured I'd also create a PR for the cybre fork.