### PR TITLE
Set drawer__pager z-index to be greater than clippy

### DIFF
--- a/app/javascript/styles/win95.scss
+++ b/app/javascript/styles/win95.scss
@@ -159,6 +159,7 @@ body.admin {
 
 .drawer__pager {
   overflow-y:auto;
+  z-index:1;
 }
 
 .privacy-dropdown__dropdown {


### PR DESCRIPTION
this is mostly an annoyance on mobile. when the keyboard makes the viewport size really tiny clippy can overlap the visibility options

before:
![screenshot from 2018-08-21 22-55-28](https://user-images.githubusercontent.com/3506025/44440325-9008b500-a595-11e8-9b34-41677e6d1046.png)

after:
![screenshot from 2018-08-21 22-55-41](https://user-images.githubusercontent.com/3506025/44440333-9565ff80-a595-11e8-8f48-7728203a037a.png)
